### PR TITLE
Convergence/diversity tracking added

### DIFF
--- a/ArgABM.nlogo
+++ b/ArgABM.nlogo
@@ -102,7 +102,8 @@ globals [max-learn small-movement color-move colla-networks share-structure
   round-converged last-converged-th scientists g-knowledge g-max-ticks
   g-red-theories g-exit-case g-exit-condition? g-learn-set g-learn-set-theories
   g-learn-frequency g-exit-case-start g-exit-case-duration g-comp-pop-counter
-  g-active-colla-networks g-static-phase]
+  g-active-colla-networks g-static-phase g-convergence-start
+  g-convergence-duration]
 
 
 
@@ -138,6 +139,8 @@ to setup [rs]
   set g-learn-set-theories no-turtles
   set g-exit-case-start n-values 2 [[]]
   set g-exit-case-duration n-values 2 [[]]
+  set g-convergence-start []
+  set g-convergence-duration []
   create-discovery-landscape
   define-attack-relation
   distribute-researchers
@@ -164,13 +167,17 @@ to go [exit?]
     if exit? and not g-exit-condition? [
       set g-exit-condition? exit-condition
       if g-exit-condition? [
+        let present-time ticks
         ifelse necessary-convergence [
           if g-exit-case != 0 [
             set-exit-case-duration g-exit-case
           ]
         ][
           final-commands
+          ; +1 b/c the final-commands effectively happen in an additional round
+          set present-time ticks + 1
         ]
+        set-convergence-duration present-time
         if knowledge-tracking [
           save-tracked-knowledge
         ]
@@ -1397,6 +1404,24 @@ This is a variable indicating the world state in order to reduce computational e
 * **2**: in case of `g-exit-case` 2 and researchers receiving a random item via `learn-random-item` for which they have not yet run `compute-subjective-attacked`
 * **3**: in case of `g-exit-case` 2 and researchers not having received any new information since they ran `compute-subjective-attacked` the last time  
 
+#### g-convergence-start
+
+* format: list
+* example [10 150]  
+
+Protocols the rounds in which each convergence episode (= all researchers on one theory) started. See `g-convergence-duration` below for more details.  
+
+#### g-convergence-duration
+
+* format: list
+* example: [5 20]  
+
+Protocols for how long the convergence episodes (= all researchers continuously on the same theory) were lasting. In the example here (using the `g-convergence-start` data from above) there were two episodes of convergence: 
+
+* round 10 - 15: all scientists are converged on one theory
+* round 150 - 170: all scientists are converged on one theory  
+
+The rest of the time researchers were spread among more than one theory i.e. diversity was maintained.  
 
 
 ### Researchers-own
@@ -1909,6 +1934,9 @@ NetLogo 6.0.4
     <metric>frequency-exit-case 2</metric>
     <metric>g-exit-case</metric>
     <metric>time-of-first-red-theory</metric>
+    <metric>cum-convergence-duration</metric>
+    <metric>frequency-convergence</metric>
+    <metric>frequency-convergence-flips</metric>
     <enumeratedValueSet variable="network-structure">
       <value value="&quot;cycle&quot;"/>
       <value value="&quot;wheel&quot;"/>

--- a/README.md
+++ b/README.md
@@ -652,6 +652,24 @@ This is a variable indicating the world state in order to reduce computational e
 * **2**: in case of `g-exit-case` 2 and researchers receiving a random item via `learn-random-item` for which they have not yet run `compute-subjective-attacked`
 * **3**: in case of `g-exit-case` 2 and researchers not having received any new information since they ran `compute-subjective-attacked` the last time  
 
+#### g-convergence-start
+
+* format: list
+* example [10 150]  
+
+Protocols the rounds in which each convergence episode (= all researchers on one theory) started. See `g-convergence-duration` below for more details.  
+
+#### g-convergence-duration
+
+* format: list
+* example: [5 20]  
+
+Protocols for how long the convergence episodes (= all researchers continuously on the same theory) were lasting. In the example here (using the `g-convergence-start` data from above) there were two episodes of convergence: 
+
+* round 10 - 15: all scientists are converged on one theory
+* round 150 - 170: all scientists are converged on one theory  
+
+The rest of the time researchers were spread among more than one theory i.e. diversity was maintained.  
 
 
 ### Researchers-own

--- a/protocol.nls
+++ b/protocol.nls
@@ -592,6 +592,9 @@ end
 ; reports how often during the run convergence flipped from being on one theory 
 ; directly to another theory without any diversity period in between
 to-report frequency-convergence-flips
+  if empty? g-convergence-duration [
+    report 0
+  ]
   let convergence-end (map + g-convergence-start g-convergence-duration)
   let flip-freq length filter [curentry -> member? curentry g-convergence-start]
     convergence-end

--- a/protocol.nls
+++ b/protocol.nls
@@ -77,6 +77,20 @@ end
 
 
 
+; records the durations of the convergences during the run
+; argument: present-time = the time-point at which the last convergence ended, 
+;   type: integer
+to set-convergence-duration [present-time]
+  if last-converged-th != -1 [
+    let new-duration (present-time - last g-convergence-start)
+    set g-convergence-duration lput new-duration g-convergence-duration
+  ]
+end
+
+
+
+
+
 ; the exit-condition determines when a given run is considered to be finished. 
 ; In case `necessary-convergence` is selected in the interface a run is 
 ; finished as soon as all researchers converge on the best theory. Otherwise a 
@@ -549,4 +563,42 @@ to-report time-of-first-red-theory
     report ticks
   ]
   report min reduced-case-starts
+end
+
+
+
+
+
+; reports the cumulative time researchers were converged (=all on the same
+; theory) during the run 
+to-report cum-convergence-duration
+  report sum g-convergence-duration
+end
+
+
+
+
+
+; reports how many periods of convergence (=all researchers continuously on the 
+; same theory) occurred during the run
+to-report frequency-convergence
+  report length g-convergence-duration
+end
+
+
+
+
+
+; reports how often during the run convergence flipped from being on one theory 
+; directly to another theory without any diversity period in between
+to-report frequency-convergence-flips
+  let convergence-end (map + g-convergence-start g-convergence-duration)
+  let flip-freq length filter [curentry -> member? curentry g-convergence-start]
+    convergence-end
+  ; the last convergence in the last round of the run (if it happens) is not a
+  ; convergence flip (although a 2nd to last convergence happening there can be)
+  if last g-convergence-duration = 0 [
+    set flip-freq flip-freq - 1
+  ]
+  report flip-freq
 end

--- a/setup.nls
+++ b/setup.nls
@@ -575,10 +575,14 @@ to compute-popularity [update-pluralist?]
   ifelse [myscientists] of most-pop-th = scientists [
     if last-converged-th != most-pop-th [
       ; the +1 correction is b/c the variable is set before `tick` happens
-      set round-converged ticks + 1
+      let current-convergence-time ticks + 1
+      set round-converged current-convergence-time
+      set-convergence-duration current-convergence-time
+      set g-convergence-start lput current-convergence-time g-convergence-start
       set last-converged-th most-pop-th
     ]
   ][
+    set-convergence-duration (ticks + 1)
     set round-converged -1
     set last-converged-th -1
   ]
@@ -763,7 +767,12 @@ to record-initial-scientists
     set initial-scientists count researchers in-radius 0
     if initial-scientists = scientists [
       set last-converged-th self
+      set g-convergence-start lput 0 g-convergence-start
     ]
+  ]
+  if last-converged-th = 0 [
+    set last-converged-th -1
+    set round-converged -1
   ]
 end
 

--- a/strategies.nls
+++ b/strategies.nls
@@ -19,7 +19,7 @@
 ; processed? is a boolean dummy variable which marks attacks which have
 ; successfully attacked during the secondary-attackers phase
 to-report admissibility-calc-core [attackset]
-  ; take the attacks which are themselves uncontested in  the objective 
+  ; take the attacks which are themselves uncontested in the objective 
   ; landscape. The destination of this attacks will be non-admissible and 
   ; attacks coming from there are void.
   let prime-attackers attackset with [uncontested]
@@ -38,12 +38,12 @@ to-report admissibility-calc-core [attackset]
     ask secondary-attackers [
       set processed? false
       if not [any? my-in-attacks with [
-        member? self secondary-attackers]] of end1  [
+        member? self secondary-attackers]] of end1 [
         set another-loop? true
         set sucattacked-cache (turtle-set sucattacked-cache end2)
         set processed? true
-      ]     
-    ]   
+      ]
+    ]
     ; Of those secondary-attackers which were successful, the destination
     ; (= end2) gets added to the non-admissible turtle-set and attacks
     ; starting from there are rendered void and are therefore removed from


### PR DESCRIPTION
* These changes are introduced to give us a clearer picture on the nature of transient-diversity within our runs.
* Two new global variables (`g-convergence-start`  and `g-convergence-duration`) have been introduced to record this data. They are documented in the Infotab and Readme.
* Two old globals (`last-converged-th` and `round-converged`) are now already set to the correct values during the setup procedure (`record-initial-scientists` procedure). This had to be implemented b/c scientists can start a run from a converged state, which we want to track.
* The tracking construct itself is mainly part of the `compute-popularity` procedure, but an additional step which has to be executed at the end of the run (the recording of the last convergence) can be found in the `go` procedure. The sub-procedure which records the duration each time a convergence episode ends (`set-convergence-duration`) can be found in protocol.nls.
* The three new reporters (cum-convergence-duration, frequency-convergence, frequency-convergence-flips) which track how long and often convergence occurs during the runs have been added to the default BehaviorSpace experiment